### PR TITLE
Avoid a StackOverflow when re-emitting packets

### DIFF
--- a/lib.js
+++ b/lib.js
@@ -928,6 +928,13 @@ MQTT.prototype.packetHandler = function(data) {
     }
     // Get the data for this packet
     var pData = data.slice(1 + dLen.lenBy, pLen);
+
+    // Avoid an infinite data emit loop
+    if (pData.length < 1) {
+        this.partData = data;
+        return;
+    }
+
     // more than one packet? re-emit it so we handle it later
     if (data.length > pLen) {
         this.client.emit("data", data.slice(pLen, data.length));


### PR DESCRIPTION
I noticed an issue with my Flic hub where `this.client.emit("data", data.slice(pLen, data.length))` was being called every time `packetHandler` was invoked, which would lead to a StackOverfow error and cause the module to crash and restart.

It looks like I was getting some sort of mismatch between what the library thought needed to be re-sent and what was actually being re-sent. `pData` would actually be empty, leading to nothing changing in the next packet handler call. This PR adds a check to see if `pData` is empty before continuing, and follows the same logic as when `data` is empty.

I don't understand the code here well enough to know if this is a proper fix, but all my buttons seem to still work correctly, and it fixes the constant crash loop.